### PR TITLE
Fix crash when JSON description is null

### DIFF
--- a/Sources/ExtraBrain/Entities/TimeEntry.swift
+++ b/Sources/ExtraBrain/Entities/TimeEntry.swift
@@ -32,7 +32,7 @@ extension TimeEntry: Decodable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         id = try values.decode(Int.self, forKey: .id)
-        description = try values.decode(String.self, forKey: .description)
+        description = (try? values.decode(String.self, forKey: .description)) ?? ""
         duration = try values.decode(TimeInterval.self, forKey: .duration)
 
         if let projectId = try? values.decode(Int.self, forKey: .projectId),


### PR DESCRIPTION
In the rails application the value of description can be null. This
caused the CLI to crash. We fix this by set description to an empty
string by default if the description is not parsable.