### PR TITLE
Remove sudo required from travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os:
   - osx
 language: generic
 osx_image: xcode10.1
-sudo: required
 dist: trusty
 install:
   - swift package resolve


### PR DESCRIPTION
The container based build environment is fully deprecated and sudo will
always be available in the the virtual machine.